### PR TITLE
fix syntax error of KeySet.txt

### DIFF
--- a/KeySet.txt
+++ b/KeySet.txt
@@ -65,5 +65,5 @@ cea6c427188'
 },
 {"1":2,"-1":"P-384","-2":"7cvYCcdU22WCwW1tZXR8iuzJLWGcd46xfxO1XJs-SPU","-3":"DzhJXgz9RI6TseNmwEfLoNVns8UmvONsPzQDop2dKoo","-4":"Uqr4fay_qYQykwcNCB2efj_NFaQRRQ-6fHZm763jt5w"},
 {"1":2,"-1":"P-384","-2":"u824K6sAZAbypMg_f0WPDE4-zq8RInaGPCvk02d3zawMrSUBZNYASSj7wYrLtQ7m","-3":"W1AqPxy6wxLM9pAl_AMJulsC9ToiOjSRcg4MBMLTHClO8p8boUwE8OfjTwharQFC","-4":"Tpz0-PNSmn_8L4FLxgKOoTZS0_3FYEDNtv3ghWbLYUTyLGa5uwExbkm599isJTgl"},
-{"1":2,"-1":"P-384","-2":"8_W0gLUTLb__hp6SDTqeJykre69AQtfsc9plRdh_ap35gJhmVHsvpGpbQKIaM2_27InmyvF1Fv9K3zunBt9nHgE","-3":"AQMe7-xEu5s49sLiFXIGsY4FVgAxFe6HW1nT3sqOcqgkFs0_Y7fWpDkAGLc1Og3Qqmt7-8-7d0fTW1nNtf5RJqdM","-4":"Af9IsRGlT6A-iPBgaSukjyB6A0LP6GTcw9wO-e71yUfMbb9YJMnjYFq1DBjjvxEyI35mjP-k115wW0q9LxYPvlRt"}             b
+{"1":2,"-1":"P-384","-2":"8_W0gLUTLb__hp6SDTqeJykre69AQtfsc9plRdh_ap35gJhmVHsvpGpbQKIaM2_27InmyvF1Fv9K3zunBt9nHgE","-3":"AQMe7-xEu5s49sLiFXIGsY4FVgAxFe6HW1nT3sqOcqgkFs0_Y7fWpDkAGLc1Og3Qqmt7-8-7d0fTW1nNtf5RJqdM","-4":"Af9IsRGlT6A-iPBgaSukjyB6A0LP6GTcw9wO-e71yUfMbb9YJMnjYFq1DBjjvxEyI35mjP-k115wW0q9LxYPvlRt"}
 ]


### PR DESCRIPTION
[KeySet.txt](https://github.com/cose-wg/Examples/blob/b7a0a92bcdcba1e35c2075140e0c7c64e6e13551/KeySet.txt) is represented using Extended Diagnostic Notation, but https://cbor.me/ can't parse it.

<img width="961" alt="image" src="https://github.com/cose-wg/Examples/assets/1157344/149ea318-8cd5-4993-ad09-2a2da77bdebb">

It looks there is extra `b` in the end of the file.
I removed it.